### PR TITLE
Handle aliased indices

### DIFF
--- a/lib/es-reindex.rb
+++ b/lib/es-reindex.rb
@@ -131,7 +131,7 @@ class ESReindex
       return false
     end
 
-    @settings = settings[sidx]["settings"]
+    @settings = fetch_index_config(settings, sidx)["settings"]
     @settings["index"]["version"].delete "created"
   end
 
@@ -140,7 +140,7 @@ class ESReindex
       log "Failed to obtain original index '#{surl}/#{sidx}' mappings!", :error
       return false
     end
-    @mappings = mappings[sidx]["mappings"]
+    @mappings = fetch_index_config(mappings, sidx)["mappings"]
   end
 
   def copy_docs
@@ -240,6 +240,13 @@ private
     out = out == '0' ? '' : out + ' days, '
     out << sprintf('%u:%02u:%02u', *t)
     out
+  end
+
+  # Accounts for aliased indices. When index is aliased there will not
+  # be a key nor in settings, nor in mappings. But there will be the
+  # only key for original index name.
+  def fetch_index_config(config, index)
+    config.fetch(index) { config.values.first }
   end
 
 end

--- a/spec/integration/copy_spec.rb
+++ b/spec/integration/copy_spec.rb
@@ -3,12 +3,16 @@ require 'spec_helper'
 describe "copy!", type: :integration do
   let(:orig_index_name)  { "test_index" }
   let(:new_index_name)   { "test_index_clone" }
+  let(:orig_index_alias) { "test_index_alias" }
 
   let!(:original_klass)  { test_klass index_name: orig_index_name }
   let!(:new_klass)       { test_klass index_name: new_index_name }
 
   let(:test_post)        { original_klass.create id: 1, text: 'test_post' }
   let(:test_post_2)      { new_klass.create      id: 2, text: 'other_post' }
+
+  let(:elastic_client)   { Elasticsearch::Client.new(host: ES_HOST, log: false) }
+  let(:alias_index)      { elastic_client.indices.put_alias(index: orig_index_name, name: orig_index_alias) }
 
   # Create the index (test_index) on the test_klass:
   before do
@@ -19,6 +23,12 @@ describe "copy!", type: :integration do
 
   it "copies the index" do
     ESReindex.copy! "#{ES_HOST}/#{orig_index_name}", "#{ES_HOST}/#{new_index_name}", {}
+    expect(new_klass.find test_post.id).to be_present
+  end
+
+  it "copies the aliased index" do
+    alias_index
+    ESReindex.copy! "#{ES_HOST}/#{orig_index_alias}", "#{ES_HOST}/#{new_index_name}", {}
     expect(new_klass.find test_post.id).to be_present
   end
 

--- a/spec/integration/reindex_spec.rb
+++ b/spec/integration/reindex_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe "reindex!", type: :integration do
   let(:orig_index_name)  { "test_index" }
   let(:new_index_name)   { "test_index_clone" }
+  let(:orig_index_alias) { "test_index_alias" }
 
   let!(:original_klass)  { test_klass index_name: orig_index_name }
   let!(:new_klass)       { test_klass index_name: new_index_name, attributes: [:foo] }
 
   let(:test_post)        { original_klass.create id: 1, text: 'test_post' }
+
+  let(:elastic_client)   { Elasticsearch::Client.new(host: ES_HOST, log: false) }
+  let(:alias_index)      { elastic_client.indices.put_alias(index: orig_index_name, name: orig_index_alias) }
 
   # Create the index (test_index) on the test_klass:
   before do
@@ -16,16 +20,27 @@ describe "reindex!", type: :integration do
     original_klass.refresh_index!
   end
 
-  let(:reindexed_post) { new_klass.find test_post.id }
+  let(:reindexed_post)  { new_klass.find test_post.id }
 
-  let(:reindex)    { ESReindex.reindex! "#{ES_HOST}/#{orig_index_name}", "#{ES_HOST}/#{new_index_name}", opts }
-  let(:mappings)   { ->{ new_klass.mappings } }
-  let(:settings)   { ->{ new_klass.settings } }
-  let(:other_opts) { {} }
-  let(:opts)       { {mappings: mappings, settings: settings}.merge other_opts }
+  let(:reindex)         { ESReindex.reindex! "#{ES_HOST}/#{orig_index_name}", "#{ES_HOST}/#{new_index_name}", opts }
+  let(:aliased_reindex) { ESReindex.reindex! "#{ES_HOST}/#{orig_index_alias}", "#{ES_HOST}/#{new_index_name}", opts }
+  let(:mappings)        { ->{ new_klass.mappings } }
+  let(:settings)        { ->{ new_klass.settings } }
+  let(:other_opts)      { {} }
+  let(:opts)            { {mappings: mappings, settings: settings}.merge other_opts }
 
   it "reindexes with the selected mappings" do
     reindex
+
+    expect(reindexed_post.id).to   eq test_post.id
+    expect(reindexed_post.text).to eq test_post.text
+    expect(reindexed_post).to respond_to :foo
+  end
+
+  it "reindexes alias with the selected mappings" do
+    alias_index
+
+    aliased_reindex
 
     expect(reindexed_post.id).to   eq test_post.id
     expect(reindexed_post.text).to eq test_post.text


### PR DESCRIPTION
Fixes #16 

Handles aliased indexes on source side. Affects fetching logic for source settings and mappings.

Usual index:

```
curl localhost:9200/index_a/_settings
#=> { index_a: ... }
```

Aliased index:

```
curl localhost:9200/index_production/_settings
#=> { index_a: ... }
```

Currently it just fetches settings/mappings by source index name for normal indexes. And if there is no such key in response from elasticsearch api, it just uses first key available.

Do you see any need to iterate over it further? For example I see possibility of fetching list of aliases from elasticsearch api and checking if source index is alias or not, and if it is, then use its original index name instead.
