### PR TITLE
Add -nm option to not copy mappings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,11 +25,12 @@ and mapping copied.
 
 Usage:
 
-  ./es-reindex.rb [-r] [-f <frame>] [source_url/]<index> [destination_url/]<index>
+  ./es-reindex [options] [source_url/]<index> [destination_url/]<index>
 
-    - -r - remove the index in the new location first
-    - -f - specify frame size to be obtained with one fetch during scrolling
-    - -u - update existing documents (default: only create non-existing)
+    - -r  - remove the index in the new location first
+    - -f  - specify frame size to be obtained with one fetch during scrolling
+    - -u  - update existing documents (default: only create non-existing)
+    - -nm - dont't copy mappings and settings
     - optional source/destination urls default to http://127.0.0.1:9200
 ```
 

--- a/bin/es-reindex
+++ b/bin/es-reindex
@@ -12,11 +12,12 @@ if ARGV.size == 0 or ARGV[0] =~ /^-(?:h|-?help)$/
 
   Usage:
 
-    #{__FILE__} [-r] [-f <frame>] [source_url/]<index> [destination_url/]<index>
+    #{__FILE__} [options] [source_url/]<index> [destination_url/]<index>
 
-      - -r - remove the index in the new location first
-      - -f - specify frame size to be obtained with one fetch during scrolling
-      - -u - update existing documents (default: only create non-existing)
+      - -r  - remove the index in the new location first
+      - -f  - specify frame size to be obtained with one fetch during scrolling
+      - -u  - update existing documents (default: only create non-existing)
+      - -nm - dont't copy mappings and settings
       - optional source/destination urls default to http://127.0.0.1:9200
   \n"
 

--- a/lib/es-reindex.rb
+++ b/lib/es-reindex.rb
@@ -108,8 +108,8 @@ class ESReindex
         return false unless get_mappings
         create_msg = " with settings & mappings from '#{surl}/#{sidx}'"
       else
-        @mappings = options[:mappings].call
-        @settings = options[:settings].call
+        @mappings = options[:mappings].nil? ? {} : options[:mappings].call
+        @settings = options[:settings].nil? ? {} : options[:settings].call
         create_msg = ""
       end
 

--- a/lib/es-reindex/args_parser.rb
+++ b/lib/es-reindex/args_parser.rb
@@ -2,13 +2,19 @@ class ESReindex
   class ArgsParser
 
     def self.parse(args)
-      remove, update, frame, src, dst = false, false, 1000, nil, nil
+      remove = false
+      update = false
+      frame = 1000
+      src = nil
+      dst = nil
+      copy_mappings = true
 
       while args[0]
         case arg = args.shift
         when '-r' then remove = true
         when '-f' then frame  = args.shift.to_i
         when '-u' then update = true
+        when '-nm' then copy_mappings = false
         else
           u = arg.chomp '/'
           !src ? (src = u) : !dst ? (dst = u) :
@@ -19,7 +25,8 @@ class ESReindex
       return src, dst, {
         remove: remove,
         frame:  frame,
-        update: update
+        update: update,
+        copy_mappings: copy_mappings,
       }
     end
   end

--- a/spec/es-reindex/args_parser_spec.rb
+++ b/spec/es-reindex/args_parser_spec.rb
@@ -74,4 +74,20 @@ describe ESReindex::ArgsParser do
       expect(parsed_opts[:update]).to be true
     end
   end
+
+  context "without -nm" do
+    let(:args) { ["-u"] }
+
+    it "sets copy_mappings to true" do
+      expect(parsed_opts[:copy_mappings]).to be true
+    end
+  end
+
+  context "with -nm" do
+    let(:args) { ["-u", "-nm"] }
+
+    it "sets copy_mappings to false" do
+      expect(parsed_opts[:copy_mappings]).to be false
+    end
+  end
 end


### PR DESCRIPTION
Not sure if this is the correct way of doing it but i'm using a elastichsearch with "dynamic_templates" configured and copying the mappings seems to override those mappings
